### PR TITLE
run the task before registering the task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 ## Amazon ECS "Run Task" Action for GitHub Actions
 
-Runs an Amazon ECS task on ECS cluster. This action was forked from [smitp/amazon-ecs-run-task](https://github.com/smitp/amazon-ecs-run-task). It has been amended to accept subnet ids and security groups as inputs. This enables the action to run tasks with `network_mode` set to `awsvpc`. When running this kind of task, the `runTask` function requires a `network_configuration` parameter with both subnet ids and security groups specified.
+This action was forked from [smitp/amazon-ecs-run-task](https://github.com/smitp/amazon-ecs-run-task).
 
-**Table of Contents**
+This action does two things:
+
+1. It runs the input task definition.
+2. After step 1 successfully completes, it registers the task definition.
+
+The reason for registering the task definition *after* running the task is to allow the GITHUB_TOKEN to be used as a task definition envirionment variable.
+The task definition is registered only after the GITHUB_TOKEN is no longer valid.
+
+To enable the action to run tasks with `network_mode` set to `awsvpc`, the action accepts subnet ids and security groups as inputs.
+
+## Table of Contents
 
 <!-- toc -->
 
@@ -24,6 +34,7 @@ Runs an Amazon ECS task on ECS cluster. This action was forked from [smitp/amazo
       uses: Enterprise-CMCS/amazon-ecs-run-task@master
       with:
         task-definition: task-definition.json
+        task-definition-arn: arn:aws:ecs:us-east-1:12345:task-definition/mytask-dev:42
         cluster: my-cluster
         count: 1
         subnets: subnet-1, subnet-2, subnet-3
@@ -99,6 +110,7 @@ The task definition file can be updated prior to deployment with the new contain
       uses: Enterprise-CMCS/amazon-ecs-run-task@master
       with:
         task-definition: task-definition.json
+        task-definition-arn: arn:aws:ecs:us-east-1:12345:task-definition/mytask-dev:42
         cluster: my-cluster
         count: 1
         started-by: github-actions-${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The task definition file can be updated prior to deployment with the new contain
         image: ${{ steps.build-image.outputs.image }}
 
     - name: Run Task on Amazon ECS
-      uses: Enterprise-CMCS/amazon-ecs-run-task@master
+      uses: Enterprise-CMCS/amazon-ecs-run-task@vXYZ
       with:
         task-definition: task-definition.json
         task-definition-arn: arn:aws:ecs:us-east-1:12345:task-definition/mytask-dev:42

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,10 @@ branding:
   color: 'orange'
 inputs:
   task-definition:
-    description: 'The name of ECS task definition'
+    description: 'The filename (<file>.json) of the ECS task definition'
     required: true
+  task-definition-arn:
+    description: 'The ECS task definition ARN'
   cluster:
     description: "The name of the ECS cluster. Will default to the 'default' cluster"
     required: true


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-1626

*Description of changes:*
We use GITHUB_TOKEN as a task environment variable. Environment variables are stored in the clear in a task definition. When the task definition is registered, the token is visible in the task definition.

This is okay because the token expires at the end of a GitHub Actions job. However, if the task definition is registered first (and the token is exposed) and the task takes a while to run then a valid token is exposed for the duration of the long-running task.

This commit runs the task first. Immediately after the task finishes running, the task definition is registered. Since this action is the last step of the job, the token expires after the registration completes. The token that is exposd in the task definition after it expires.

Tested:
Printed out the task definition that was used to the run the task.
Printed out the task definition that was registered after the task ran.
The action runs task definition revision artillery-dev:107.
The action registers task definition revision artillery-dev:108.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
